### PR TITLE
Add menu_class argument to $args

### DIFF
--- a/wp_bem_menu.php
+++ b/wp_bem_menu.php
@@ -126,9 +126,11 @@ function bem_menu($location = "main_menu", $css_class_prefix = 'main-menu', $css
     $args = array(
         'theme_location'    => $location,
         'container'         => false,
-        'items_wrap'        => '<ul class="' . $css_class_prefix . ' ' . $modifiers . '">%3$s</ul>',
+        'menu_class'        => $css_class_prefix,
+        'items_wrap'        => '<ul class="' . $modifiers . '">%3$s</ul>',
         'walker'            => new walker_texas_ranger($css_class_prefix, true)
     );
+
     
     if (has_nav_menu($location)){
         return wp_nav_menu($args);


### PR DESCRIPTION
When updating to WP-4.4 the UL tag stopped receiving the custom class that is provided in the `bem_menu()` function call, but still received modifiers.

By adding the `menu_class` option to the `$args` array with a value of `$css_class_prefix`, then removing `$css_class_prefix` from `items_wrap` it appeared to fix the issue.

