### PR TITLE
Custom css

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ $this->item_css_classes = array(
 );
 
 ```
+
+## Custom Css classes set in wp-admin>menus
+
+If you add a custom class to a menu item in wp-admin Wordpress-Bem-Menu now adds the class to the item converted to a BEM modifier. If for example you add a class of `my-class` to a menu item the output would be `<li class="main-menu  main-menu__item  main-menu__item--my-class"></li>` 

--- a/wp_bem_menu.php
+++ b/wp_bem_menu.php
@@ -89,7 +89,7 @@ class walker_texas_ranger extends Walker_Nav_Menu {
             'active_ancestor_class' => in_array("current-menu-ancestor",$item->classes) ? $prefix . $suffix['ancestor_of_active_item'] : '',
             'depth_class'           => $depth >=1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
             'item_id_class'         => $prefix . '__item--'. $item->ID,
-            'user_class'            => $prefix . '__item--'. $this->user_class
+            'user_class'            => $this->user_class !== '' ? $prefix . '__item--'. $this->user_class : ''
         );
 
         // convert array to string excluding any empty values

--- a/wp_bem_menu.php
+++ b/wp_bem_menu.php
@@ -13,20 +13,27 @@ class walker_texas_ranger extends Walker_Nav_Menu {
         
         // Define menu item names appropriately
 
-        $this->item_css_classes = array(
-            'item'                      => $this->css_class_prefix . '__item',
-            'parent_item'               => $this->css_class_prefix . '__item--parent',
-            'active_item'               => $this->css_class_prefix . '__item--active',
-            'parent_of_active_item'     => $this->css_class_prefix . '__item--parent--active',
-            'ancestor_of_active_item'   => $this->css_class_prefix . '__item--ancestor--active',
-            'sub_menu'                  => $this->css_class_prefix . '__sub-menu',
-            'sub_menu_item'             => $this->css_class_prefix . '__sub-menu__item',
+        $this->item_css_class_suffixes = array(
+            'item'                      => '__item',
+            'parent_item'               => '__item--parent',
+            'active_item'               => '__item--active',
+            'parent_of_active_item'     => '__item--parent--active',
+            'ancestor_of_active_item'   => '__item--ancestor--active',
+            'sub_menu'                  => '__sub-menu',
+            'sub_menu_item'             => '__sub-menu__item'
         );
+
     }
 
     // Check for children
 
     function display_element( $element, &$children_elements, $max_depth, $depth=0, $args, &$output ){
+        
+        //echo '<pre>';
+        //print_r($element->classes[0]);
+        //echo '</pre>';
+
+        $this->user_class = $element->classes[0];
         
         $id_field = $this->db_fields['id'];
         
@@ -44,9 +51,12 @@ class walker_texas_ranger extends Walker_Nav_Menu {
         
         $indent = str_repeat("\t", $real_depth);
 
+        $prefix = $this->css_class_prefix;
+        $suffix = $this->item_css_class_suffixes;
+
         $classes = array(
-            $this->item_css_classes['sub_menu'],
-            $this->item_css_classes['sub_menu']. '--' . $real_depth
+            $prefix . $suffix['sub_menu'],
+            $prefix . $suffix['sub_menu']. '--' . $real_depth
         );
 
         $class_names = implode( ' ', $classes );
@@ -66,22 +76,26 @@ class walker_texas_ranger extends Walker_Nav_Menu {
 
         // item classes
 
-        $item_classes = array(
-            'item_class'            => $depth == 0 ? $this->item_css_classes['item'] : '',
-            'parent_class'          => $args->has_children ? $parent_class = $this->item_css_classes['parent_item'] : '',
-            'active_page_class'     => in_array("current-menu-item",$item->classes) ? $this->item_css_classes['active_item'] : '',
-            'active_parent_class'   => in_array("current-menu-parent",$item->classes) ? $this->item_css_classes['parent_of_active_item'] : '',
-            'active_ancestor_class' => in_array("current-menu-ancestor",$item->classes) ? $this->item_css_classes['ancestor_of_active_item'] : '',
-            'depth_class'           => $depth >=1 ? $this->item_css_classes['sub_menu_item'] . ' ' .$this->item_css_classes['sub_menu'] . '--' . $depth . '__item' : '',
-            'item_id_class'         => $this->css_class_prefix . '__item--'. $item->ID
+        $prefix = $this->css_class_prefix;
+        $user_class_prefix = $this->user_class;
+
+        $suffix = $this->item_css_class_suffixes;
+
+        $item_classes =  array(
+            'item_class'            => $depth == 0 ? $prefix . $suffix['item'] : '',
+            'parent_class'          => $args->has_children ? $parent_class = $prefix . $suffix['parent_item'] : '',
+            'active_page_class'     => in_array("current-menu-item",$item->classes) ? $prefix . $suffix['active_item'] : '',
+            'active_parent_class'   => in_array("current-menu-parent",$item->classes) ? $prefix . $suffix['parent_of_active_item'] : '',
+            'active_ancestor_class' => in_array("current-menu-ancestor",$item->classes) ? $prefix . $suffix['ancestor_of_active_item'] : '',
+            'depth_class'           => $depth >=1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
+            'item_id_class'         => $prefix . '__item--'. $item->ID,
+            'user_class'            => $prefix . '__item--'. $this->user_class
         );
 
         // convert array to string excluding any empty values
-
         $class_string = implode("  ", array_filter($item_classes));
 
         // Add the classes to the wrapping <li>
-
         $output .= $indent . '<li class="' . $class_string . '">';
 
         // link attributes

--- a/wp_bem_menu.php
+++ b/wp_bem_menu.php
@@ -28,13 +28,7 @@ class walker_texas_ranger extends Walker_Nav_Menu {
     // Check for children
 
     function display_element( $element, &$children_elements, $max_depth, $depth=0, $args, &$output ){
-        
-        //echo '<pre>';
-        //print_r($element->classes[0]);
-        //echo '</pre>';
-
-        $this->user_class = $element->classes[0];
-        
+                
         $id_field = $this->db_fields['id'];
         
         if ( is_object( $args[0] ) ) {
@@ -74,11 +68,7 @@ class walker_texas_ranger extends Walker_Nav_Menu {
         
         $indent = ( $depth > 0 ? str_repeat( "    ", $depth ) : '' ); // code indent
 
-        // item classes
-
         $prefix = $this->css_class_prefix;
-        $user_class_prefix = $this->user_class;
-
         $suffix = $this->item_css_class_suffixes;
 
         $item_classes =  array(
@@ -88,8 +78,8 @@ class walker_texas_ranger extends Walker_Nav_Menu {
             'active_parent_class'   => in_array("current-menu-parent",$item->classes) ? $prefix . $suffix['parent_of_active_item'] : '',
             'active_ancestor_class' => in_array("current-menu-ancestor",$item->classes) ? $prefix . $suffix['ancestor_of_active_item'] : '',
             'depth_class'           => $depth >=1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
-            'item_id_class'         => $prefix . '__item--'. $item->ID,
-            'user_class'            => $this->user_class !== '' ? $prefix . '__item--'. $this->user_class : ''
+            'item_id_class'         => $prefix . '__item--'. $item->object_id,
+            'user_class'            => $item->classes[0] !== '' ? $prefix . '__item--'. $item->classes[0] : ''
         );
 
         // convert array to string excluding any empty values


### PR DESCRIPTION
In response to #8 I have modified the menu output so that custom css classes set in WordPress admin/menus are added to the list item with markup as below:

```html
<ul class="main-menu">
    <li class="main-menu__item  main-menu__item--1  main-menu__item--my-awesome-class">
        <a href="http://localhost/e3/">Home</a>
    </li>
    <li class="main-menu__item  main-menu__item--parent  main-menu__item--2">
        <a href="http://localhost/e3/our-story/">Our Story</a>
	<ul class="main-menu__sub-menu  main-menu__sub-menu--1">
            <li class="main-menu__sub-menu__item main-menu__sub-menu--1__item  main-menu__item--3  main-menu__item--my-sub-menu-class">
                <a href="http://localhost/e3/our-story/">Our Story</a>
            </li>
            <li class="main-menu__sub-menu__item main-menu__sub-menu--1__item  main-menu__item--4  main-menu__item--my-other-sub-menu-class">
                <a href="http://localhost/e3/our-team/">Our Team</a>
             </li>
        </ul>
    </li>
</ul>
```

In the above example I added classes to a few of the menu  items in WordPress admin. `my-awesome-class` `my-sub-menu-class` `my-other-sub-menu-class`. Each of them is added to their respoective menu items and adheres to the strict BEM naming conventions.